### PR TITLE
Add GCP CloudSQL Database option

### DIFF
--- a/packages/database/composition-gcp.yaml
+++ b/packages/database/composition-gcp.yaml
@@ -1,0 +1,84 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: compositeinstances.gcp.database.crossflux.io
+  labels:
+    provider: gcp
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: database.crossflux.io/v1alpha1
+    kind: CompositeInstance
+  resources:
+    - base:
+        apiVersion: database.gcp.crossplane.io/v1beta1
+        kind: CloudSQLInstance
+        spec:
+          forProvider:
+            databaseVersion: MYSQL_5_7
+            region: us-central1
+            settings:
+              tier: db-n1-standard-1
+              dataDiskType: PD_SSD
+              ipConfiguration:
+                ipv4Enabled: true
+                authorizedNetworks:
+                  - value: "0.0.0.0/0"
+          writeConnectionSecretToRef:
+            namespace: crossplane-system
+      patches:
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-mysql"
+        - fromFieldPath: "spec.parameters.storageGB"
+          toFieldPath: "spec.forProvider.settings.dataDiskSizeGb"
+      connectionDetails:
+        - fromConnectionSecretKey: username
+        - fromConnectionSecretKey: password
+        - fromConnectionSecretKey: endpoint
+        - name: port
+          value: "3306"
+    - base:
+        apiVersion: mysql.sql.crossplane.io/v1alpha1
+        kind: ProviderConfig
+        metadata:
+          name: default
+        spec:
+          credentials:
+            source: MySQLConnectionSecret
+            connectionSecretRef:
+              namespace: default
+              name: db-conn
+      patches:
+        - fromFieldPath: metadata.uid
+          toFieldPath: metadata.name
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.credentials.connectionSecretRef.namespace
+        # This ProviderConfig uses the above RDSInstance's connection secret as
+        # its credentials secret.
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: spec.credentials.connectionSecretRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-mysql"
+      readinessChecks:
+        - type: None
+    - base:
+        apiVersion: mysql.sql.crossplane.io/v1alpha1
+        kind: Database
+        metadata:
+          annotations:
+            crossplane.io/external-name: my-db
+        spec:
+          providerConfigRef:
+            name: default
+      patches:
+      # TODO: patch external name
+        - fromFieldPath: metadata.uid
+          toFieldPath: spec.providerConfigRef.name
+        - fromFieldPath: spec.parameters.dbName
+          toFieldPath: metadata.annotations[crossplane.io/external-name]

--- a/packages/database/crossplane.yaml
+++ b/packages/database/crossplane.yaml
@@ -8,5 +8,7 @@ spec:
   dependsOn:
     - provider: crossplane/provider-aws
       version: ">=v0.16.0"
+    - provider: crossplane/provider-gcp
+      version: ">=v0.16.0"
     - provider: crossplane/provider-sql
       version: "=v0.2.0-rc.1.7.gd4b363c"

--- a/platform/configurations/database.yaml
+++ b/platform/configurations/database.yaml
@@ -3,7 +3,7 @@ kind: Configuration
 metadata:
   name: database
 spec:
-  package: hasheddan/crossflux-database:v0.2.0
+  package: hasheddan/crossflux-database:v0.3.0
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1

--- a/platform/provider-configs/gcp.yaml
+++ b/platform/provider-configs/gcp.yaml
@@ -1,0 +1,12 @@
+apiVersion: gcp.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  projectID: crossplane-playground
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: gcp-creds
+      key: creds


### PR DESCRIPTION
Update the crossflux platform to be allow teams to request databases on GCP.