### PR TITLE
resolve VPC to the one with the proper label

### DIFF
--- a/teams/infra/aws/default-vpc.yaml
+++ b/teams/infra/aws/default-vpc.yaml
@@ -27,4 +27,7 @@ spec:
     region: us-east-1
     groupName: default
     description: default VPC security group - updated
+    vpcIdSelector:
+      matchLabels:
+        networks.aws.crossflux.io/network-id: default
   deletionPolicy: Orphan


### PR DESCRIPTION
The fix is required in case there are multiple VPCs in a given account. otherwise the wrong one will be picked.